### PR TITLE
glide2x, glide3x: On MSVC, don't treat warning as error for glide tests.

### DIFF
--- a/glide2x/cvg/glide/tests/Makefile.win32
+++ b/glide2x/cvg/glide/tests/Makefile.win32
@@ -28,7 +28,7 @@ TOP = ../../..
 CPU ?= 6
 
 CC = cl
-CFLAGS = -nologo -W3 -WX -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
+CFLAGS = -nologo -W3 -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
 CFLAGS += -I$(TOP)/$(FX_GLIDE_HW)/glide/src -I$(TOP)/$(FX_GLIDE_HW)/incsrc
 CFLAGS += -I$(TOP)/swlibs/fxmisc
 CFLAGS += -D__WIN32__ -DCVG

--- a/glide2x/h3/glide/tests/Makefile.win32
+++ b/glide2x/h3/glide/tests/Makefile.win32
@@ -28,7 +28,7 @@ TOP = ../../..
 CPU ?= 6
 
 CC = cl
-CFLAGS = -nologo -W3 -WX -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
+CFLAGS = -nologo -W3 -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
 CFLAGS += -I$(TOP)/$(FX_GLIDE_HW)/glide/src -I$(TOP)/$(FX_GLIDE_HW)/incsrc
 CFLAGS += -I$(TOP)/swlibs/fxmisc
 CFLAGS += -D__WIN32__ -DH3

--- a/glide2x/sst1/glide/tests/Makefile.win32
+++ b/glide2x/sst1/glide/tests/Makefile.win32
@@ -37,7 +37,7 @@ TOP = ../../..
 CPU ?= 6
 
 CC = cl
-CFLAGS = -nologo -W3 -WX -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
+CFLAGS = -nologo -W3 -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
 CFLAGS += -I$(TOP)/$(FX_HW_BASE)/glide/src -I$(TOP)/$(FX_HW_BASE)/incsrc -I$(TOP)/$(FX_HW_BASE)/init
 CFLAGS += -I$(TOP)/swlibs/fxmisc
 CFLAGS += -D__WIN32__ $(HWDEF)

--- a/glide3x/cvg/glide3/tests/Makefile.win32
+++ b/glide3x/cvg/glide3/tests/Makefile.win32
@@ -28,7 +28,7 @@ TOP = ../../..
 CPU ?= 6
 
 CC = cl
-CFLAGS = -nologo -W3 -WX -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
+CFLAGS = -nologo -W3 -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
 CFLAGS += -I$(TOP)/$(FX_GLIDE_HW)/glide3/src -I$(TOP)/$(FX_GLIDE_HW)/incsrc
 CFLAGS += -I$(TOP)/swlibs/fxmisc
 CFLAGS += -D__WIN32__ -DCVG

--- a/glide3x/h3/glide3/tests/Makefile.win32
+++ b/glide3x/h3/glide3/tests/Makefile.win32
@@ -28,7 +28,7 @@ TOP = ../../..
 CPU ?= 6
 
 CC = cl
-CFLAGS = -nologo -W3 -WX -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
+CFLAGS = -nologo -W3 -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
 CFLAGS += -I$(TOP)/$(FX_GLIDE_HW)/glide3/src -I$(TOP)/$(FX_GLIDE_HW)/incsrc
 CFLAGS += -I$(TOP)/swlibs/fxmisc
 CFLAGS += -D__WIN32__ -DH3

--- a/glide3x/h5/glide3/tests/Makefile.win32
+++ b/glide3x/h5/glide3/tests/Makefile.win32
@@ -37,7 +37,7 @@ FLAGS  = $(FLAGS) -DGLIDE3=1 -DGLIDE3_ALPHA=1
 CC   = cl
 LINK = link
 
-CFLAGS  = -Ox -G6 -W3 -WX -c -D__MSC__=1 -D_X86_=1 -DNULL=0 -D_WIN32=1 -DWIN32=1 -D__WIN32__=1 -DSTRICT
+CFLAGS  = -Ox -G6 -W3 -c -D__MSC__=1 -D_X86_=1 -DNULL=0 -D_WIN32=1 -DWIN32=1 -D__WIN32__=1 -DSTRICT
 LFLAGS  = -nologo /SUBSYSTEM:CONSOLE /OPT:WIN98 /MACHINE:IX86
 
 #################################

--- a/glide3x/sst1/glide3/tests/Makefile.win32
+++ b/glide3x/sst1/glide3/tests/Makefile.win32
@@ -37,7 +37,7 @@ TOP = ../../..
 CPU ?= 6
 
 CC = cl
-CFLAGS = -nologo -W3 -WX -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
+CFLAGS = -nologo -W3 -D__MSC__=1 -DNDEBUG -G$(CPU) -O2 -MT
 CFLAGS += -I$(TOP)/$(FX_HW_BASE)/glide3/src -I$(TOP)/$(FX_HW_BASE)/incsrc -I$(TOP)/$(FX_HW_BASE)/init
 CFLAGS += -I$(TOP)/swlibs/fxmisc
 CFLAGS += -D__WIN32__ $(HWDEF)


### PR DESCRIPTION
When use MSVC6 to compile, some of tests files for glide 2 and glide 3 produce warnings.